### PR TITLE
Remove hardcoded paths

### DIFF
--- a/radare2.iss
+++ b/radare2.iss
@@ -5,9 +5,6 @@
 #define MyAppVersion "Radare2-w32-0.9.9-git"
 #define MyAppPublisher "Radare.org"
 #define MyAppURL "http://radare.org/"
-#define Radare2Location "Z:\tmp\radare2-win-installer\*"
-#define LicenceLocation "Z:\tmp\COPYING.LESSER"
-#define IcoLocation "Z:\tmp\radare2.ico"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.


### PR DESCRIPTION
Just add 
 -DRadare2Location=Z:\tmp\radare2-win-installer*
 -DLicenceLocation=Z:\tmp\COPYING.LESSER
 -DIcoLocation=Z:\tmp\radare2.ico
in the command line when calling `iscc`
