### PR TITLE
More flexible install script

### DIFF
--- a/radare2.iss
+++ b/radare2.iss
@@ -60,8 +60,8 @@ Source: {#Radare2Location} ; DestDir: "{app}"; Flags: ignoreversion recursesubdi
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Registry]
-Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment\"; ValueType: string; ValueName: "Path"; ValueData: "{reg:HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\,Path};{app}" 
-Root: HKCR; SubKey: "*\shell\Radare2"; ValueType: string; ValueData: "Open in Radare2"
-Root: HKCR; SubKey: "*\shell\Radare2\command"; ValueType: string; ValueData: "C:\Program Files (x86)\Radare2\radare2.exe %1"
-Root: HKCR; SubKey: "*\shell\Radare2d"; ValueType: string; ValueData: "Open in Radare2 debugger"
-Root: HKCR; SubKey: "*\shell\Radare2d\command"; ValueType: string; ValueData: "C:\Program Files (x86)\Radare2\radare2.exe -d %1"
+Root: HKLM; SubKey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment\"; ValueType: string; ValueName: "Path"; ValueData: "{reg:HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\,Path};{app}\"; Flags: uninsdeletekey
+Root: HKCR; SubKey: "*\shell\Radare2"; ValueType: string; ValueData: "Open in Radare2"; Flags: uninsdeletekey
+Root: HKCR; SubKey: "*\shell\Radare2\command"; ValueType: string; ValueData: "{app}\radare2.exe %1"; Flags: uninsdeletekey
+Root: HKCR; SubKey: "*\shell\Radare2d"; ValueType: string; ValueData: "Open in Radare2 debugger"; Flags: uninsdeletekey
+Root: HKCR; SubKey: "*\shell\Radare2d\command"; ValueType: string; ValueData: "{app}\radare2.exe -d %1"; Flags: uninsdeletekey


### PR DESCRIPTION
- Fixed PATH issue
- Make right click work wherever the user installed radare2
- Remove registers on uninstall (right click context, PATH variable)